### PR TITLE
Feature/night writer

### DIFF
--- a/lib/alphabet.rb
+++ b/lib/alphabet.rb
@@ -33,7 +33,7 @@ class Alphabet
     }
   end
 
-  def convert_to_braille(character)
+  def english_to_braille(character)
     @characters.find do |letter, braille|
       if character == letter
         return braille

--- a/lib/alphabet.rb
+++ b/lib/alphabet.rb
@@ -41,4 +41,16 @@ class Alphabet
     end
   end
 
+  def format_braille(unformatted_message)
+    line_1 = []
+    line_2 = []
+    line_3 = []
+    unformatted_message.each do |braille_char|
+      line_1 << braille_char[0]
+      line_2 << braille_char[1]
+      line_3 << braille_char[2]
+    end
+    "#{line_1.join}\n#{line_2.join}\n#{line_3.join}\n"
+  end
+
 end

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -28,11 +28,8 @@ class NightWriter < Alphabet
   def translate_message_to_braille
     # WIP
     braille_message = []
-    read_file.each_char do |character|
-      require 'pry'; binding.pry
-      braille_message << convert_to_braille(character)
-    end
-
+    read_file.each_char {|character| braille_message << english_to_braille(character)}
+    # format_braille(braille_message)
   end
 
 

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -1,10 +1,13 @@
-class NightWriter
+require './lib/alphabet'
+
+class NightWriter < Alphabet
   attr_reader :incoming_text,
               :translate_to_braille
               
   def initialize(incoming_text, translate_to_braille)
     @incoming_text = incoming_text
     @translate_to_braille = translate_to_braille
+    super()
   end
 
   def read_file
@@ -23,7 +26,13 @@ class NightWriter
   end
 
   def translate_message_to_braille
-    
+    # WIP
+    braille_message = []
+    read_file.each_char do |character|
+      require 'pry'; binding.pry
+      braille_message << convert_to_braille(character)
+    end
+
   end
 
 

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -20,9 +20,8 @@ class NightWriter < Alphabet
   end
 
   def write_to_file
-    new_message = read_file
     writer = File.open(@outgoing_braille, "w")
-    writer.write(new_message)
+    writer.write(translate_to_braille)
   end
 
   def translate_to_braille

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -11,8 +11,8 @@ class NightWriter < Alphabet
   end
 
   def read_file
-    message = File.open(@incoming_text, "r")
-    message.read
+    text = File.open(@incoming_text, "r")
+    text.read
   end
 
   def print_reply
@@ -27,9 +27,9 @@ class NightWriter < Alphabet
 
   def translate_message_to_braille
     # WIP
-    braille_message = []
-    read_file.each_char {|character| braille_message << english_to_braille(character)}
-    # format_braille(braille_message)
+    message = []
+    read_file.each_char {|character| message << english_to_braille(character)}
+    # format_braille(message)
   end
 
 

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -22,6 +22,10 @@ class NightWriter
     writer.write(new_message)
   end
 
+  def translate_message_to_braille
+    
+  end
+
 
 end
 

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -2,11 +2,11 @@ require './lib/alphabet'
 
 class NightWriter < Alphabet
   attr_reader :incoming_text,
-              :translate_to_braille
+              :outgoing_braille
               
-  def initialize(incoming_text, translate_to_braille)
+  def initialize(incoming_text, outgoing_braille)
     @incoming_text = incoming_text
-    @translate_to_braille = translate_to_braille
+    @outgoing_braille = outgoing_braille
     super()
   end
 
@@ -16,16 +16,16 @@ class NightWriter < Alphabet
   end
 
   def print_reply
-    p "Created '#{@translate_to_braille}' containing #{read_file.size} characters"
+    p "Created '#{@outgoing_braille}' containing #{read_file.size} characters"
   end
 
   def write_to_file
     new_message = read_file
-    writer = File.open(@translate_to_braille, "w")
+    writer = File.open(@outgoing_braille, "w")
     writer.write(new_message)
   end
 
-  def translate_message_to_braille
+  def translate_to_braille
     message = []
     read_file.each_char {|character| message << english_to_braille(character)}
     format_braille(message)

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -26,10 +26,9 @@ class NightWriter < Alphabet
   end
 
   def translate_message_to_braille
-    # WIP
     message = []
     read_file.each_char {|character| message << english_to_braille(character)}
-    # format_braille(message)
+    format_braille(message)
   end
 
 

--- a/spec/alphabet_spec.rb
+++ b/spec/alphabet_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Alphabet do
       alphabet = Alphabet.new
       sing_char = "h"
 
-      expect(alphabet.convert_to_braille(sing_char)).to eq(["0.", "00", ".."])
+      expect(alphabet.english_to_braille(sing_char)).to eq(["0.", "00", ".."])
     end
 
   end

--- a/spec/alphabet_spec.rb
+++ b/spec/alphabet_spec.rb
@@ -28,7 +28,15 @@ RSpec.describe Alphabet do
 
       expect(@alphabet.english_to_braille(sing_char)).to eq(["0.", "00", ".."])
     end
-
   end
+
+  describe '#format_braille' do
+    it 'can format braille array to three lines of strings' do
+      raw_hello = [["0.", "00", ".."], ["0.", ".0", ".."], ["0.", "0.", "0."],
+                   ["0.", "0.", "0."], ["0.", ".0", "0."]]
+      formatted_hello = "0.0.0.0.0.\n00.00.0..0\n....0.0.0.\n"
+      expect(@alphabet.format_braille(raw_hello)).to eq(formatted_hello)
+    end
+  end    
 
 end

--- a/spec/alphabet_spec.rb
+++ b/spec/alphabet_spec.rb
@@ -1,33 +1,32 @@
 require 'spec_helper'
 
 RSpec.describe Alphabet do
+  before(:each) do
+    @alphabet = Alphabet.new
+  end
+  
   describe '#initialize' do
     it 'exists' do
-      alphabet = Alphabet.new
-
-      expect(alphabet).to be_an_instance_of(Alphabet)
+      expect(@alphabet).to be_an_instance_of(Alphabet)
     end
 
     it 'has readable attributes' do
-      alphabet = Alphabet.new
-      
-      expect(alphabet.characters["h"]).to eq(["0.", "00", ".."])
-      expect(alphabet.characters["e"]).to eq(["0.", ".0", ".."])
-      expect(alphabet.characters["l"]).to eq(["0.", "0.", "0."])
-      expect(alphabet.characters["o"]).to eq(["0.", ".0", "0."])
-      expect(alphabet.characters[" "]).to eq(["..", "..", ".."])
-      expect(alphabet.characters["w"]).to eq([".0", "00", ".0"])
-      expect(alphabet.characters["r"]).to eq(["0.", "00", "0."])
-      expect(alphabet.characters["d"]).to eq(["00", ".0", ".."])
+      expect(@alphabet.characters["h"]).to eq(["0.", "00", ".."])
+      expect(@alphabet.characters["e"]).to eq(["0.", ".0", ".."])
+      expect(@alphabet.characters["l"]).to eq(["0.", "0.", "0."])
+      expect(@alphabet.characters["o"]).to eq(["0.", ".0", "0."])
+      expect(@alphabet.characters[" "]).to eq(["..", "..", ".."])
+      expect(@alphabet.characters["w"]).to eq([".0", "00", ".0"])
+      expect(@alphabet.characters["r"]).to eq(["0.", "00", "0."])
+      expect(@alphabet.characters["d"]).to eq(["00", ".0", ".."])
     end
   end
 
   describe '#english_to_braille' do
     it 'can translate a single character' do
-      alphabet = Alphabet.new
       sing_char = "h"
 
-      expect(alphabet.english_to_braille(sing_char)).to eq(["0.", "00", ".."])
+      expect(@alphabet.english_to_braille(sing_char)).to eq(["0.", "00", ".."])
     end
 
   end

--- a/spec/night_writer_spec.rb
+++ b/spec/night_writer_spec.rb
@@ -33,4 +33,13 @@ RSpec.describe NightWriter do
       expect(File.exists?("braille.txt")).to eq(true)
     end
   end
+
+  describe '#translate_message_to_braille' do
+    it 'can translate a message from letters to braille' do
+      night_writer = NightWriter.new("hello_world.txt", "braille.txt")
+      expected = "0.0.0.0.0....00.0.0.00\n00.00.0..0..00.0000..0\n....0.0.0....00.0.0...\n"
+      
+      expect(night_writer.translate_message_to_braille).to eq(expected)
+    end
+  end
 end

--- a/spec/night_writer_spec.rb
+++ b/spec/night_writer_spec.rb
@@ -1,34 +1,31 @@
 require 'spec_helper'
 
 RSpec.describe NightWriter do
+  before(:each) do
+    @night_writer = NightWriter.new("hello_world.txt", "braille.txt")
+  end
+
   describe '#initialize' do
     it 'exists' do
-      night_writer = NightWriter.new("hello_world.txt", "braille.txt")
-
-      expect(night_writer).to be_an_instance_of(NightWriter)
+      expect(@night_writer).to be_an_instance_of(NightWriter)
     end
   end
 
   describe '#read_file' do
     it 'can read a file' do
-      night_writer = NightWriter.new("hello_world.txt", "braille.txt")
-
-      expect(night_writer.read_file).to eq("hello world")
+      expect(@night_writer.read_file).to eq("hello world")
     end
   end
 
   describe '#print_reply' do
     it 'can print a reply based on character numbers' do
-      night_writer = NightWriter.new("hello_world.txt", "braille.txt")
-
-      expect(night_writer.print_reply).to eq("Created 'braille.txt' containing 11 characters")
+      expect(@night_writer.print_reply).to eq("Created 'braille.txt' containing 11 characters")
     end
   end
   
   describe '#write_to_file' do
     it 'can write a new file' do
-      night_writer = NightWriter.new("hello_world.txt", "braille.txt")
-      night_writer.write_to_file
+      @night_writer.write_to_file
 
       expect(File.exists?("braille.txt")).to eq(true)
     end
@@ -36,10 +33,9 @@ RSpec.describe NightWriter do
 
   describe '#translate_message_to_braille' do
     it 'can translate a message from letters to braille' do
-      night_writer = NightWriter.new("hello_world.txt", "braille.txt")
       expected = "0.0.0.0.0....00.0.0.00\n00.00.0..0..00.0000..0\n....0.0.0....00.0.0...\n"
       
-      expect(night_writer.translate_message_to_braille).to eq(expected)
+      expect(@night_writer.translate_message_to_braille).to eq(expected)
     end
   end
 end

--- a/spec/night_writer_spec.rb
+++ b/spec/night_writer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe NightWriter do
   end
 
   describe '#translate_message_to_braille' do
-    it 'can translate a message from letters to braille' do
+    xit 'can translate a message from letters to braille' do
       night_writer = NightWriter.new("hello_world.txt", "braille.txt")
       expected = "0.0.0.0.0....00.0.0.00\n00.00.0..0..00.0000..0\n....0.0.0....00.0.0...\n"
       

--- a/spec/night_writer_spec.rb
+++ b/spec/night_writer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe NightWriter do
   end
 
   describe '#translate_message_to_braille' do
-    xit 'can translate a message from letters to braille' do
+    it 'can translate a message from letters to braille' do
       night_writer = NightWriter.new("hello_world.txt", "braille.txt")
       expected = "0.0.0.0.0....00.0.0.00\n00.00.0..0..00.0000..0\n....0.0.0....00.0.0...\n"
       

--- a/spec/night_writer_spec.rb
+++ b/spec/night_writer_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe NightWriter do
     end
   end
 
-  describe '#translate_message_to_braille' do
+  describe '#translate_to_braille' do
     it 'can translate a message from letters to braille' do
       expected = "0.0.0.0.0....00.0.0.00\n00.00.0..0..00.0000..0\n....0.0.0....00.0.0...\n"
       
-      expect(@night_writer.translate_message_to_braille).to eq(expected)
+      expect(@night_writer.translate_to_braille).to eq(expected)
     end
   end
 end

--- a/writer_runner.rb
+++ b/writer_runner.rb
@@ -4,5 +4,6 @@ incoming_text = ARGV[0]
 outgoing_braille = ARGV[1]
 
 night_writer = NightWriter.new(incoming_text, outgoing_braille)
+night_writer.write_to_file
 night_writer.print_reply
 

--- a/writer_runner.rb
+++ b/writer_runner.rb
@@ -1,8 +1,8 @@
 require './lib/night_writer'
 
 incoming_text = ARGV[0]
-translate_to_braille = ARGV[1]
+outgoing_braille = ARGV[1]
 
-night_writer = NightWriter.new(incoming_text, translate_to_braille)
+night_writer = NightWriter.new(incoming_text, outgoing_braille)
 night_writer.print_reply
 


### PR DESCRIPTION
This PR adds the format_braille method to the Alphabet class, and the translate_to_braille method to the NightWriter class.  These two methods, along with a refactor of the write_to_file method, allows the runner file to take in a text file of lower-cased words and output a file with its braille equivalent.  The program still needs a method to put in a line break after 80 characters.
Testing is showing 100% coverage for all methods.